### PR TITLE
[Commit Signing for Github Apps] Create a composite Github Action that creates signed copies of local commits on a remote branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The action is intended to be used by Github Actions as a follow-up to a 'commit'
           git commit -m "Once pushed to the remote, this commit will appear as authored by the GitHub App and verified"
     
       - name: "Push commits"
-        uses: ./.github/actions/create-signed-remote-commits
+        uses: Asana/push-signed-commits@v1
         with:
             github-token: ${{ steps.generate-token.outputs.token }}
             local_branch_name: "main"
@@ -37,3 +37,14 @@ The action is intended to be used by Github Actions as a follow-up to a 'commit'
 ```
 
 As a final step, the local branch will be reset to match the remote branch using `git reset --hard`
+
+
+## Background and context
+
+Per https://github.com/orgs/community/discussions/50055, historically the only way to create 'signed' commits as a Github App installation was to use the Git database APIs (described at https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28). These APIs are complicated, and it's a challenging multi-step process to implement commit verification with them. 
+
+In 2021, Github released the createCommitOnBranch GraphQL mutation, which makes it easier to add, update, and delete files in a branch of a repository. This new API offers a simpler way to commit changes compared to the existing Git database REST APIs. With the new createCommitOnBranch mutation, you do not need to manually create blobs and trees via separate API calls before creating the commit. This allows you to add, update, or delete multiple files in a single API call.
+
+The push-signed-commits composite action uses the new createCommitOnBranch GraphQL endpoint to create verified commits on a remote branch. This GraphQL API extracts authorship information from the credential used for authentication, and automatically marks commits created using Github App installation credentials as "verified". 
+
+Read more about this new mutation and its conveniences here: https://github.blog/changelog/2021-09-13-a-simpler-api-for-authoring-commits/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # push-signed-commits
 This composite Github Action uses the createCommitOnBranch GraphQL mutation to allow Github Apps to push 'Verified' commits to Github.
+
+Since this action changes the content of the commits (by deriving authorship information and signing them), the hashes of the commits pushed to the remote will be different from the ones that were created locally. This is expected and is a result of the commit being signed.
+
+The action is intended to be used by Github Actions as a follow-up to a 'commit' step. For example:
+
+```yaml
+        # Retrieve an installation token for your Github App
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+            app-id: ${{ env.GITHUB_APP_ID }}
+            private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+
+
+      - name: "create a commit"
+        id: create-commit
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          git config --global user.name "Login will be determined by the Github API based on the creator of the token"
+          git config --global user.email ""
+          touch "test.txt"
+          echo "Hello, world, from the first commit!" >> "test.txt"
+          git add "test.txt"
+          git commit -m "Once pushed to the remote, this commit will appear as authored by the GitHub App and verified"
+    
+      - name: "Push commits"
+        uses: ./.github/actions/create-signed-remote-commits
+        with:
+            github-token: ${{ steps.generate-token.outputs.token }}
+            local_branch_name: "main"
+            remote_name: "origin"
+            remote_branch_name: "main"
+```
+
+As a final step, the local branch will be reset to match the remote branch using `git reset --hard`

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,56 @@
+name: Diff a local and remote branch, and use createCommitOnBranch to push copies of local commits to the remote
+
+description: |
+  This composite Github Action was designed to allow Github Apps to push 'Verified' commits to Github. 
+  
+  Per https://github.com/orgs/community/discussions/50055, historically the only way to create 'signed' commits as a Github App installation was to use the Git database APIs (described at https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28), which are fairly complicated.
+  
+  In 2021, Github released the createCommitOnBranch GraphQL mutation, which makes it easier to add, update, and delete files in a branch of a repository. This new API offers a simpler way to commit changes compared to the existing Git database REST APIs. With the new createCommitOnBranch mutation, you do not need to manually create blobs and trees before creating the commit. This allows you to add, update, or delete multiple files in a single API call.
+  
+  The create-signed-remote-commits composite action uses the new createCommitOnBranch GraphQL endpoint to create verified commits on a remote branch. This GraphQL API extracts authorship information from the credential used for authentication, and automatically marks commits created using Github App installation credentials as "verified". 
+  
+  Read more about this new mutation and its conveniences here: https://github.blog/changelog/2021-09-13-a-simpler-api-for-authoring-commits/
+
+inputs:
+  github-token:
+    description: 'GitHub token'
+    required: true
+  owner:
+    description: 'Repository owner'
+    required: true
+    default: ${{ github.repository_owner }}
+  repo:
+    description: 'Repository name'
+    required: true
+    default: ${{ github.repository }}
+  local_branch_name:
+    description: 'Local branch name'
+    required: true
+  remote_branch_name:
+    description: 'Remote branch name - should not include refs/heads/ prefix or origin/ prefix'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Mask token
+      run: echo "::add-mask::${{ inputs.github-token }}"
+      shell: bash
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install requests
+      shell: bash
+    - name: Run script
+      run: |
+        python create_commits.py ${{ inputs.github-token }} ${{ inputs.repo }} ${{ inputs.local_branch_name }} ${{ inputs.remote_branch_name }}
+      shell: bash
+    - name: Reset the local branch to the remote branch
+      if: success()
+      run: |
+        git fetch origin
+        git reset --hard origin/${{ inputs.remote_branch_name }}
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ description: |
   
   In 2021, Github released the createCommitOnBranch GraphQL mutation, which makes it easier to add, update, and delete files in a branch of a repository. This new API offers a simpler way to commit changes compared to the existing Git database REST APIs. With the new createCommitOnBranch mutation, you do not need to manually create blobs and trees via separate API calls before creating the commit. This allows you to add, update, or delete multiple files in a single API call.
   
-  The create-signed-remote-commits composite action uses the new createCommitOnBranch GraphQL endpoint to create verified commits on a remote branch. This GraphQL API extracts authorship information from the credential used for authentication, and automatically marks commits created using Github App installation credentials as "verified". 
+  The push-signed-commits composite action uses the new createCommitOnBranch GraphQL endpoint to create verified commits on a remote branch. This GraphQL API extracts authorship information from the credential used for authentication, and automatically marks commits created using Github App installation credentials as "verified". 
   
   Read more about this new mutation and its conveniences here: https://github.blog/changelog/2021-09-13-a-simpler-api-for-authoring-commits/
 

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,8 @@ runs:
       run: |
         python ${{ github.action_path }}/create_commits.py ${{ inputs.github-token }} ${{ inputs.repo }} ${{ inputs.local_branch_name }} ${{ inputs.remote_branch_name }}
       shell: bash
+    # The createCommitOnBranch endpoint will dynamically generate authorship and commit verification information, which will result in different commit hashes on the remote vs. local branch. 
+    # This step will reset the local branch to have the same authorship info, verification status, and therefore commit hash (which is deterministically derived from commit contents) as the remote. 
     - name: Reset the local branch to the remote branch
       if: success()
       run: |

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ description: |
   
   Per https://github.com/orgs/community/discussions/50055, historically the only way to create 'signed' commits as a Github App installation was to use the Git database APIs (described at https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28). These APIs are complicated, and it's a challenging multi-step process to implement commit verification with them. 
   
-  In 2021, Github released the createCommitOnBranch GraphQL mutation, which makes it easier to add, update, and delete files in a branch of a repository. This new API offers a simpler way to commit changes compared to the existing Git database REST APIs. With the new createCommitOnBranch mutation, you do not need to manually create blobs and trees before creating the commit. This allows you to add, update, or delete multiple files in a single API call.
+  In 2021, Github released the createCommitOnBranch GraphQL mutation, which makes it easier to add, update, and delete files in a branch of a repository. This new API offers a simpler way to commit changes compared to the existing Git database REST APIs. With the new createCommitOnBranch mutation, you do not need to manually create blobs and trees via separate API calls before creating the commit. This allows you to add, update, or delete multiple files in a single API call.
   
   The create-signed-remote-commits composite action uses the new createCommitOnBranch GraphQL endpoint to create verified commits on a remote branch. This GraphQL API extracts authorship information from the credential used for authentication, and automatically marks commits created using Github App installation credentials as "verified". 
   

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   remote_branch_name:
     description: 'Remote branch name - should not include refs/heads/ prefix or origin/ prefix'
     required: true
+  remote_name: 
+    description: 'The name of the remote to push to, pre-configured in the local git repo. eg., `origin`'
+    default: 'origin'
 runs:
   using: 'composite'
   steps:
@@ -46,13 +49,13 @@ runs:
       shell: bash
     - name: Run script
       run: |
-        python ${{ github.action_path }}/create_commits.py ${{ inputs.github-token }} ${{ inputs.repo }} ${{ inputs.local_branch_name }} ${{ inputs.remote_branch_name }}
+        python ${{ github.action_path }}/create_commits.py ${{ inputs.github-token }} ${{ inputs.repo }} ${{ inputs.local_branch_name }} ${{ inputs.remote_name }} ${{ inputs.remote_branch_name }}
       shell: bash
     # The createCommitOnBranch endpoint will dynamically generate authorship and commit verification information, which will result in different commit hashes on the remote vs. local branch. 
     # If the creation of remote commits is successful, a final step runs. This step will reset the local branch to have the same authorship info, verification status, and therefore commit hash (which is deterministically derived from commit contents) as the remote. 
     - name: Reset the local branch to the remote branch
       if: success()
       run: |
-        git fetch origin
-        git reset --hard origin/${{ inputs.remote_branch_name }}
+        git fetch ${{ inputs.remote_name }} ${{ inputs.remote_branch_name }}
+        git reset --hard ${{ inputs.remote_name }}/${{ inputs.remote_branch_name }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
         python ${{ github.action_path }}/create_commits.py ${{ inputs.github-token }} ${{ inputs.repo }} ${{ inputs.local_branch_name }} ${{ inputs.remote_branch_name }}
       shell: bash
     # The createCommitOnBranch endpoint will dynamically generate authorship and commit verification information, which will result in different commit hashes on the remote vs. local branch. 
-    # This step will reset the local branch to have the same authorship info, verification status, and therefore commit hash (which is deterministically derived from commit contents) as the remote. 
+    # If the creation of remote commits is successful, a final step runs. This step will reset the local branch to have the same authorship info, verification status, and therefore commit hash (which is deterministically derived from commit contents) as the remote. 
     - name: Reset the local branch to the remote branch
       if: success()
       run: |

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
     - name: Reset the local branch to the remote branch
       if: success()
       run: |
-        git fetch "$REMOTE_NAME" "$REMOTE_BRANCH_NAME
+        git fetch "$REMOTE_NAME" "$REMOTE_BRANCH_NAME"
         git reset --hard "$REMOTE_NAME"/"$REMOTE_BRANCH_NAME"
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   remote_name: 
     description: 'The name of the remote to push to, pre-configured in the local git repo. eg., `origin`'
     default: 'origin'
+  log_level: 
+    description: 'Log level, specified using the standard Python logging module levels. Default is WARN. Options are DEBUG, INFO, WARN, ERROR.'
+    default: 'WARN'
 runs:
   using: 'composite'
   steps:
@@ -49,7 +52,7 @@ runs:
       shell: bash
     - name: Run script
       run: |
-        python ${{ github.action_path }}/create_commits.py "$GITHUB_TOKEN" "$REPO" "$LOCAL_BRANCH_NAME" "$REMOTE_NAME" "$REMOTE_BRANCH_NAME"
+        python ${{ github.action_path }}/create_commits.py "$GITHUB_TOKEN" "$REPO" "$LOCAL_BRANCH_NAME" "$REMOTE_NAME" "$REMOTE_BRANCH_NAME" "$LOG_LEVEL"
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
@@ -57,6 +60,7 @@ runs:
         LOCAL_BRANCH_NAME: ${{ inputs.local_branch_name }}
         REMOTE_BRANCH_NAME: ${{ inputs.remote_branch_name }}
         REMOTE_NAME: ${{ inputs.remote_name }}
+        LOG_LEVEL: ${{ inputs.log_level }}
     # The createCommitOnBranch endpoint will dynamically generate authorship and commit verification information, which will result in different commit hashes on the remote vs. local branch. 
     # If the creation of remote commits is successful, a final step runs. This step will reset the local branch to have the same authorship info, verification status, and therefore commit hash (which is deterministically derived from commit contents) as the remote. 
     - name: Reset the local branch to the remote branch

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ name: Diff a local and remote branch, and use createCommitOnBranch to push copie
 description: |
   This composite Github Action was designed to allow Github Apps to push 'Verified' commits to Github. 
   
-  Per https://github.com/orgs/community/discussions/50055, historically the only way to create 'signed' commits as a Github App installation was to use the Git database APIs (described at https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28), which are fairly complicated.
+  Per https://github.com/orgs/community/discussions/50055, historically the only way to create 'signed' commits as a Github App installation was to use the Git database APIs (described at https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28). These APIs are complicated, and it's a challenging multi-step process to implement commit verification with them. 
   
   In 2021, Github released the createCommitOnBranch GraphQL mutation, which makes it easier to add, update, and delete files in a branch of a repository. This new API offers a simpler way to commit changes compared to the existing Git database REST APIs. With the new createCommitOnBranch mutation, you do not need to manually create blobs and trees before creating the commit. This allows you to add, update, or delete multiple files in a single API call.
   

--- a/action.yml
+++ b/action.yml
@@ -49,13 +49,22 @@ runs:
       shell: bash
     - name: Run script
       run: |
-        python ${{ github.action_path }}/create_commits.py ${{ inputs.github-token }} ${{ inputs.repo }} ${{ inputs.local_branch_name }} ${{ inputs.remote_name }} ${{ inputs.remote_branch_name }}
+        python ${{ github.action_path }}/create_commits.py "$GITHUB_TOKEN" "$REPO" "$LOCAL_BRANCH_NAME" "$REMOTE_NAME" "$REMOTE_BRANCH_NAME"
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ inputs.repo }}
+        LOCAL_BRANCH_NAME: ${{ inputs.local_branch_name }}
+        REMOTE_BRANCH_NAME: ${{ inputs.remote_branch_name }}
+        REMOTE_NAME: ${{ inputs.remote_name }}
     # The createCommitOnBranch endpoint will dynamically generate authorship and commit verification information, which will result in different commit hashes on the remote vs. local branch. 
     # If the creation of remote commits is successful, a final step runs. This step will reset the local branch to have the same authorship info, verification status, and therefore commit hash (which is deterministically derived from commit contents) as the remote. 
     - name: Reset the local branch to the remote branch
       if: success()
       run: |
-        git fetch ${{ inputs.remote_name }} ${{ inputs.remote_branch_name }}
-        git reset --hard ${{ inputs.remote_name }}/${{ inputs.remote_branch_name }}
+        git fetch "$REMOTE_NAME" "$REMOTE_BRANCH_NAME
+        git reset --hard "$REMOTE_NAME"/"$REMOTE_BRANCH_NAME"
       shell: bash
+      env:
+        REMOTE_NAME: ${{ inputs.remote_name }}
+        REMOTE_BRANCH_NAME: ${{ inputs.remote_branch_name }}

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
       shell: bash
     - name: Run script
       run: |
-        python create_commits.py ${{ inputs.github-token }} ${{ inputs.repo }} ${{ inputs.local_branch_name }} ${{ inputs.remote_branch_name }}
+        python ${{ github.action_path }}/create_commits.py ${{ inputs.github-token }} ${{ inputs.repo }} ${{ inputs.local_branch_name }} ${{ inputs.remote_branch_name }}
       shell: bash
     - name: Reset the local branch to the remote branch
       if: success()

--- a/create_commits.py
+++ b/create_commits.py
@@ -131,7 +131,7 @@ def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:
                 )
             )
 
-        elif status in ["D"]:
+        elif status == "D":
             logging.debug("Deleted file detected")
             file_changes["deletions"].append(FileDeletion(path=filenames[0]))
 

--- a/create_commits.py
+++ b/create_commits.py
@@ -83,7 +83,7 @@ def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:
     # Get a list of files changed in a specific commit.
     result = subprocess.run(
         ["git", "diff", "--name-status", f"{commit_hash}~1", commit_hash],
-        capture_output=True,
+        stdout=subprocess.PIPE,
         text=True,
         check=True,
     )

--- a/create_commits.py
+++ b/create_commits.py
@@ -73,8 +73,8 @@ def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:
     # setting config variable advice.detachedHead to false to avoid verbose messages in the logs
     subprocess.run(
         ["git", "config", "advice.detachedHead", "false"],
-        capture_output=True,
         stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
         check=True,
     )
 

--- a/create_commits.py
+++ b/create_commits.py
@@ -157,7 +157,7 @@ def get_local_commits_not_on_remote(
     """
     result = subprocess.run(
         ["git", "rev-list", f"{remote_name}/{remote_branch_name}..{local_branch_name}"],
-        capture_output=True,
+        stdout=subprocess.PIPE,
         text=True,
         check=True,
     )

--- a/create_commits.py
+++ b/create_commits.py
@@ -90,10 +90,10 @@ def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:
     files_changed_by_commit = result.stdout.splitlines()
 
     logging.debug("files_changed_by_commit:\n %s", files_changed_by_commit)
-    file_changes: FileChanges = {
-        "additions": [],
-        "deletions": [],
-    }
+    file_changes = FileChanges(
+        additions=[],
+        deletions=[],
+    )
 
     # check out that commit in detached head state, so that we can pull file contents accurately
     subprocess.run(["git", "checkout", commit_hash], check=True)

--- a/create_commits.py
+++ b/create_commits.py
@@ -133,7 +133,7 @@ def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:
 
         elif status in ["D"]:
             logging.debug("Deleted file detected")
-            file_changes["deletions"].append({"path": filenames[0]})
+            file_changes["deletions"].append(FileDeletion(path=filenames[0]))
 
     # go back to the previous ref
     subprocess.run(["git", "checkout", "-"], check=True, stdout=subprocess.PIPE, text=True)

--- a/create_commits.py
+++ b/create_commits.py
@@ -136,7 +136,9 @@ def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:
             file_changes["deletions"].append(FileDeletion(path=filenames[0]))
 
     # go back to the previous ref
-    subprocess.run(["git", "checkout", "-"], check=True, stdout=subprocess.PIPE, text=True)
+    subprocess.run(
+        ["git", "checkout", "-"], check=True, stdout=subprocess.PIPE, text=True
+    )
 
     return file_changes
 
@@ -155,23 +157,21 @@ def get_local_commits_not_on_remote(
     Returns:
         list: A list of strings representing the commit hashes.
     """
-    result = subprocess.run(
+    result: list[str] = subprocess.run(
         ["git", "rev-list", f"{remote_name}/{remote_branch_name}..{local_branch_name}"],
         stdout=subprocess.PIPE,
         text=True,
         check=True,
-    )
+    ).stdout.splitlines()
     logging.info(
         "Found %s commits on the local branch that are not on the remote branch.",
-        len(result.stdout.splitlines()),
+        len(result),
     )
     logging.debug("Commits to be created on the remote branch:")
-
-    for commit_hash in result.stdout.splitlines():
-        logging.debug(commit_hash)
+    logging.debug("\n".join(result))
 
     # reverse the list so that the oldest commit is first
-    return result.stdout.splitlines()[::-1]
+    return result[::-1]
 
 
 def create_commit_on_remote_branch(

--- a/create_commits.py
+++ b/create_commits.py
@@ -74,7 +74,7 @@ def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:
     subprocess.run(
         ["git", "config", "advice.detachedHead", "false"],
         capture_output=True,
-        text=True,
+        stdout=subprocess.DEVNULL,
         check=True,
     )
 

--- a/create_commits.py
+++ b/create_commits.py
@@ -138,7 +138,7 @@ def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:
     # https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---name-status for more on the
     # --name-status parameter.
     result = subprocess.run(
-        ["git", "diff", "--name-status", f"{commit_hash}~1", commit_hash],
+        ["git", "diff", "--name-status", f"{commit_hash}^", commit_hash],
         stdout=subprocess.PIPE,
         text=True,
         check=True,

--- a/create_commits.py
+++ b/create_commits.py
@@ -136,7 +136,7 @@ def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:
             file_changes["deletions"].append({"path": filenames[0]})
 
     # go back to the previous ref
-    subprocess.run(["git", "checkout", "-"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "checkout", "-"], check=True, stdout=subprocess.PIPE, text=True)
 
     return file_changes
 

--- a/create_commits.py
+++ b/create_commits.py
@@ -505,7 +505,7 @@ if __name__ == "__main__":
     parser.add_argument("local_branch_name", help="Local branch name", type=str)
     parser.add_argument("remote_name", help="Remote name")
     parser.add_argument("remote_branch_name", help="Remote branch name")
-    parser.add_argument("log-level", default="WARN", help="Log level", type=str)
+    parser.add_argument("log_level", default="WARN", help="Log level", type=str)
     args = parser.parse_args()
 
     logging.basicConfig(level=args.log_level)

--- a/create_commits.py
+++ b/create_commits.py
@@ -1,0 +1,347 @@
+# pyright: strict
+import base64
+import subprocess
+import sys
+from typing import Optional, TypedDict
+import logging
+
+import requests
+
+
+class FileDeletion(TypedDict):
+    """
+    A type hint for the FileDeletion GraphQL input object, which is an input to the
+    FileChanges GraphQL input object.
+    https://docs.github.com/en/graphql/reference/input-objects#filedeletion
+    """
+
+    path: str
+
+
+class FileAddition(TypedDict):
+    """
+    A type hint for the FileAddition GraphQL input object, which is an input to the
+    FileChanges GraphQL input object.
+    https://docs.github.com/en/graphql/reference/input-objects#fileaddition
+    """
+
+    path: str
+    contents: str
+
+
+class FileChanges(TypedDict):
+    """
+    A type hint for the FileChanges GraphQL input object, which is an input to the
+    createCommitOnBranch mutation.
+    Read about the mutation here:
+    https://docs.github.com/en/graphql/reference/mutations#createcommitonbranch
+    And the file changes input object here:
+    https://docs.github.com/en/graphql/reference/input-objects#filechanges
+    """
+
+    additions: list[FileAddition]
+    deletions: list[FileDeletion]
+
+
+class CommitMessage(TypedDict):
+    """
+    A type hint for the CommitMessage GraphQL input object, which is an input to the
+    createCommitOnBranch mutation.
+    Read about the mutation here:
+    https://docs.github.com/en/graphql/reference/mutations#createcommitonbranch
+    And the commit message input object here:
+    https://docs.github.com/en/graphql/reference/input-objects#commitmessage
+    """
+
+    body: str
+    headline: str
+
+
+def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:
+    """
+    Create a file changes object for a specific commit.
+
+    Args:
+        commit_hash (str): The hash of the commit.
+
+    Returns:
+        dict: A dictionary representing the FileChanges object.
+    """
+
+    # setting config variable advice.detachedHead to false to avoid verbose messages in the logs
+    subprocess.run(
+        ["git", "config", "advice.detachedHead", "false"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    logging.debug("")
+    logging.debug("now working on commit hash %s", commit_hash)
+    # Get a list of files changed in a specific commit.
+    result = subprocess.run(
+        ["git", "diff", "--name-status", f"{commit_hash}~1", commit_hash],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    files_changed_by_commit = result.stdout.splitlines()
+
+    logging.debug("files_changed_by_commit:\n %s", files_changed_by_commit)
+    file_changes: FileChanges = {
+        "additions": [],
+        "deletions": [],
+    }
+
+    # check out that commit in detached head state, so that we can pull file contents accurately
+    subprocess.run(["git", "checkout", commit_hash], check=True)
+    logging.debug("output of ls after checking out commit hash:")
+    subprocess.run(["ls"], check=True)
+
+    for line in files_changed_by_commit:
+        status, *filenames = line.split("\t")
+        logging.debug("status: %s", status)
+        logging.debug("filenames: %s", filenames)
+        if status in ["A", "M"]:
+            logging.debug("Added or modified file detected")
+            with open(filenames[-1], "rb") as f:
+                contents = base64.b64encode(f.read()).decode("utf-8")
+            file_changes["additions"].append(
+                FileAddition(
+                    path=filenames[-1],
+                    contents=contents,
+                )
+            )
+        elif "R" in status or status == "R":
+            logging.debug("Renamed file detected")
+            old_name = filenames[0]
+            new_name = filenames[1]
+            logging.debug("old_name: %s", old_name)
+            logging.debug("new_name: %s", new_name)
+
+            file_changes["deletions"].append({"path": old_name})
+            with open(new_name, "rb") as f:
+                contents = base64.b64encode(f.read()).decode("utf-8")
+            file_changes["additions"].append(
+                FileAddition(
+                    path=new_name,
+                    contents=contents,
+                )
+            )
+
+        elif status in ["D"]:
+            logging.debug("Deleted file detected")
+            file_changes["deletions"].append({"path": filenames[0]})
+
+    # go back to the previous ref
+    subprocess.run(["git", "checkout", "-"], check=True, capture_output=True, text=True)
+
+    return file_changes
+
+
+def get_local_commits_not_on_remote(
+    local_branch_name: str, remote_branch_name: str
+) -> list[str]:
+    """
+    Get a list of commit hashes on the local branch that are not on the remote branch,
+    chronologically ordered from oldest to newest.
+
+    Args:
+        local_branch_name (str): The name of the local branch.
+        remote_branch_name (str): The name of the remote branch.
+
+    Returns:
+        list: A list of strings representing the commit hashes.
+    """
+    result = subprocess.run(
+        ["git", "rev-list", f"origin/{remote_branch_name}..{local_branch_name}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    logging.info(
+        "Found %s commits on the local branch that are not on the remote branch.",
+        len(result.stdout.splitlines()),
+    )
+    logging.debug("Commits to be created on the remote branch:")
+
+    for commit_hash in result.stdout.splitlines():
+        logging.debug(commit_hash)
+
+    # reverse the list so that the oldest commit is first
+    return result.stdout.splitlines()[::-1]
+
+
+def create_commit_on_remote_branch(
+    *,
+    github_token: str,
+    repository_name_with_owner: str,
+    remote_branch_name: str,
+    expected_head_oid: str,
+    file_changes: FileChanges,
+    message: CommitMessage,
+) -> str:
+    """
+    Create a commit on a remote branch using the GitHub GraphQL API.
+
+    Args:
+        github_token (str): The GitHub personal access github_token.
+        repository_name_with_owner (str): The name of the repository with the owner.
+        remote_branch_name (str): The name of the branch.
+        expected_head_oid (str): The expected git commit oid at the head of the branch prior to the commit.
+        file_changes (dict): The file changes object.
+        message (str): The commit message.
+
+    Returns:
+        str: The commit oid of the created commit.
+    """
+
+    assert not remote_branch_name.startswith(
+        "origin/"
+    ), "Do not include 'origin/' in the remote branch name."
+
+    assert not remote_branch_name.startswith(
+        "refs/heads/"
+    ), "Do not include 'refs/heads/' in the remote branch name."
+
+    url = "https://api.github.com/graphql"
+    headers = {"Authorization": f"Bearer {github_token}"}
+
+    mutation = """
+    mutation ($input: CreateCommitOnBranchInput!) {
+      createCommitOnBranch(input: $input) {
+        commit {
+          oid
+        }
+      }
+    }
+    """
+
+    graphql_input = {
+        "branch": {
+            "repositoryNameWithOwner": repository_name_with_owner,
+            "branchName": remote_branch_name,
+        },
+        "expectedHeadOid": expected_head_oid,
+        "fileChanges": file_changes,
+        "message": message,
+    }
+
+    data = {"query": mutation, "variables": {"input": graphql_input}}
+    response = requests.post(url, headers=headers, json=data)
+
+    if "errors" in response.json():
+        logging.error(response.json())
+        exit(1)
+
+    return response.json()["data"]["createCommitOnBranch"]["commit"]["oid"]
+
+
+def main(
+    *,
+    github_token: str,
+    repository_name_with_owner: str,
+    local_branch_name: str,
+    remote_branch_name: str,
+) -> None:
+    """
+    Create commits on a remote branch for each commit on the local branch that's not on the remote branch.
+
+    Note: This function assumes that the commits created on the remote branch are unlikely to have
+    the same commit ID as the local commits. This is intentional - the createCommitOnBranch mutation
+    handles commit signing and commit authorship attribution for us, so the commit contents will be
+    different than the local commits. As a result, the commit IDs/hashes will be different as well.
+
+    Args:
+        github_token (str): The GitHub personal access github_token.
+        repository_name_with_owner (str): The name of the repository with the owner.
+        local_branch_name (str): The name of the local branch.
+        remote_branch_name (str): The name of the remote branch.
+    """
+    assert not remote_branch_name.startswith(
+        "origin/"
+    ), "Do not include 'origin/' in the remote branch name."
+    assert not remote_branch_name.startswith(
+        "refs/heads/"
+    ), "Do not include 'refs/heads/' in the remote branch name."
+
+    # List of hashes for commit on the local branch that are not on the remote branch
+    new_commit_local_hashes: list[str] = get_local_commits_not_on_remote(
+        local_branch_name, remote_branch_name
+    )
+
+    # Track the OID for the most recent commit created. This will be used as the parent commit OID for the next commit.
+    last_remote_commit_created_oid: Optional[str] = None
+
+    for local_commit_hash in new_commit_local_hashes:
+        commit_message = subprocess.run(
+            ["git", "log", "--format=%B", "-n", "1", local_commit_hash],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        commit_message_lines = commit_message.split("\n")
+        headline = commit_message_lines[0]
+        body = "\n".join(commit_message_lines[1:])
+        commit_message = CommitMessage(headline=headline, body=body)
+
+        file_changes = get_file_changes_from_local_commit_hash(local_commit_hash)
+
+        # Get the commit OID of the latest commit on the remote branch
+        subprocess.run(
+            ["git", "fetch", "origin", remote_branch_name],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        remote_head_oid = subprocess.run(
+            ["git", "rev-parse", f"origin/{remote_branch_name}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert (
+            remote_head_oid == last_remote_commit_created_oid
+            or not last_remote_commit_created_oid
+        ), "The latest commit on the remote branch is not the last commit created by this script. This is either because something went wrong during commit creation, or because someone else is pushing to the remote branch as well. Aborting."
+
+        # Create a commit on the remote branch, and store the OID of the created commit in
+        # last_remote_commit_created_oid
+        last_remote_commit_created_oid = create_commit_on_remote_branch(
+            github_token=github_token,
+            repository_name_with_owner=repository_name_with_owner,
+            remote_branch_name=remote_branch_name,
+            expected_head_oid=remote_head_oid,
+            file_changes=file_changes,
+            message=commit_message,
+        )
+
+        logging.info(
+            "Created commit %s from commit sha %s on branch origin/%s with message: %s",
+            last_remote_commit_created_oid,
+            local_commit_hash,
+            remote_branch_name,
+            commit_message,
+        )
+
+    logging.info(
+        "Finished creating %s commits on the remote branch origin/%s from the local branch %s.",
+        len(new_commit_local_hashes),
+        remote_branch_name,
+        local_branch_name,
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 5:
+        print(
+            "Usage: python script.py <github_token> <repository_name_with_owner> <local_branch_name> <remote_branch_name>"
+        )
+        sys.exit(1)
+
+    main(
+        github_token=sys.argv[1],
+        repository_name_with_owner=sys.argv[2],
+        local_branch_name=sys.argv[3],
+        remote_branch_name=sys.argv[4],
+    )

--- a/create_commits.py
+++ b/create_commits.py
@@ -170,7 +170,7 @@ def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:
 
         ############# Handle Additions and Modifications #############
         if status in ["A", "M"]:
-            logging.debug("Added or modified file %s detected", filenames[-1])
+            logging.debug("Added or modified file %s detected", filenames[0])
 
             # Per Github's docs on modeling file changes:
             # https://docs.github.com/en/graphql/reference/input-objects#modeling-file-changes,
@@ -180,7 +180,7 @@ def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:
             file_changes["additions"].append(
                 FileAddition(
                     path=filenames[-1],
-                    contents=get_file_contents_at_commit(commit_hash, filenames[-1]),
+                    contents=get_file_contents_at_commit(commit_hash, filenames[0]),
                 )
             )
 


### PR DESCRIPTION
### Summary

This PR creates a composite Github Action that can be used to push 'verified' commits using a Github App credential. This is particularly useful for Asana since we have the `require_signed_commits` feature enabled for most of our protected branches. This has historically presented challenges with migrating from service accounts to Github Apps - it isn't trivial to sign commits as a Github App (see more below) and so we've had to use GPG keys from legacy service accounts to sign commits. 

This Github Action makes it easy for Github Actions to push signed commits using Github App creds. Workflows can now replace their `git push` step with the following:

```
      - name: "Push commits"
        uses: asana/push-signed-commits@v1
        with:
            github-token: ${{ steps.generate-token.outputs.token }}
            # the branch that the Github Action has already made commits to
            local_branch_name: "main"
            # remote name and branch to push to
            remote_name: "origin"
            remote_branch_name: "main"
```

#### History and context
Per https://github.com/orgs/community/discussions/50055, historically the only way to create 'signed' commits as a Github App installation was to use the Git database APIs (described at https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28). These APIs are complicated, and it's a challenging multi-step process to implement commit verification with them. 

In 2021, Github released the createCommitOnBranch GraphQL mutation, which makes it easier to add, update, and delete files in a branch of a repository. This new API offers a simpler way to commit changes compared to the existing Git database REST APIs. With the new createCommitOnBranch mutation, you do not need to manually create blobs and trees via separate API calls before creating the commit. This allows you to add, update, or delete multiple files in a single API call.

The push-signed-commits composite action uses the new createCommitOnBranch GraphQL endpoint to create verified commits on a remote branch. This GraphQL API extracts authorship information from the credential used for authentication, and automatically marks commits created using Github App installation credentials as "verified". 



Asana tasks:
https://app.asana.com/0/1200487107890647/1206847019352850/f


Relevant deployment: 

CC: @mattbryant-asana @skeggse @suzyng83209

### Test Plan
Ran the test workflow here: https://github.com/harshita-gupta/github-app-testing/actions/workflows/test.yml


### Risks



Pull Request: https://github.com/Asana/push-signed-commits/pull/1
