### PR TITLE
Bump setup-python to a more recent version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
       run: echo "::add-mask::${{ inputs.github-token }}"
       shell: bash
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.9'
     - name: Install dependencies


### PR DESCRIPTION
When using this workflow we face errors raised by Github as follows: "The action actions/setup-python@v2 is not allowed in DataDog/datadog-agent because all actions must be from a repository owned by your enterprise, created by GitHub, verified in the GitHub Marketplace, or match one". Even if we should not have errors here I suppose bumping the version can fix the issue we see