### PR TITLE
Add python-version input to allow callers to specify Python version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,9 +32,12 @@ inputs:
   remote_name: 
     description: 'The name of the remote to push to, pre-configured in the local git repo. eg., `origin`'
     default: 'origin'
-  log_level: 
+  log_level:
     description: 'Log level, specified using the standard Python logging module levels. Default is WARN. Options are DEBUG, INFO, WARN, ERROR.'
     default: 'WARN'
+  python-version:
+    description: 'Python version to use. Defaults to 3.9 for backwards compatibility.'
+    default: '3.9'
 runs:
   using: 'composite'
   steps:
@@ -44,7 +47,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: ${{ inputs.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
     description: 'Log level, specified using the standard Python logging module levels. Default is WARN. Options are DEBUG, INFO, WARN, ERROR.'
     default: 'WARN'
   python-version:
-    description: 'Python version to use. Defaults to 3.9 for backwards compatibility.'
+    description: 'Python version to use. Defaults to 3.9.'
     default: '3.9'
 runs:
   using: 'composite'


### PR DESCRIPTION
## Problem

The action hardcodes `python-version: '3.9'` in its `Set up Python` step. This causes the caller's Python environment to be set to 3.9 for the remaining duration of the action after this step. If callers work around this by setting python version again, they lose their previously-installed pip packages.

## Change

Adds an optional `python-version` input (default: `'3.9'`) that is passed through to `actions/setup-python`. Callers that want to preserve their Python version can pass it explicitly:

```yaml
- uses: Asana/push-signed-commits@v1
  with:
    github-token: ${{ steps.get-token.outputs.app-token }}
    python-version: '3.11'
    # ... other inputs
```

Fully backwards-compatible — existing callers that don't pass `python-version` continue to get 3.9.