### PR TITLE
create_commits.py: dont assume utf-8

### DIFF
--- a/create_commits.py
+++ b/create_commits.py
@@ -107,16 +107,16 @@ def get_file_contents_at_commit(commit_hash: str, filename: str) -> str:
     Returns:
         bytes: The contents of the file, encoded in utf-8
     """
-    # get the file contents as utf-8 bytes
-    text_contents = subprocess.run(
+    # get the file contents as raw bytes (not text mode, to support binary files)
+    raw_contents = subprocess.run(
         ["git", "show", f"{commit_hash}:{filename}"],
         stdout=subprocess.PIPE,
-        text=True,
+        text=False,
         check=True,
-    ).stdout.encode("utf-8")
+    ).stdout
 
     # encode the file contents as a base64 string and return the string
-    return base64.b64encode(text_contents).decode("utf-8")
+    return base64.b64encode(raw_contents).decode("utf-8")
 
 
 def get_file_changes_from_local_commit_hash(commit_hash: str) -> FileChanges:


### PR DESCRIPTION
this allows the commits to be successfully pushed even if they are not UTF-8 - eg generated artifacts or binaries.

previously, this would fail with decoding errors:
```
Traceback (most recent call last):
  File "/home/runner/work/_actions/asana/push-signed-commits/d615ca88d8e1a946734c24970d1e7a6c56f34897/create_commits.py", line 572, in <module>
    main(
  File "/home/runner/work/_actions/asana/push-signed-commits/d615ca88d8e1a946734c24970d1e7a6c56f34897/create_commits.py", line 459, in main
    file_changes = get_file_changes_from_local_commit_hash(local_commit_hash)
  File "/home/runner/work/_actions/asana/push-signed-commits/d615ca88d8e1a946734c24970d1e7a6c56f34897/create_commits.py", line 193, in get_file_changes_from_local_commit_hash
    contents=get_file_contents_at_commit(commit_hash, filenames[0]),
  File "/home/runner/work/_actions/asana/push-signed-commits/d615ca88d8e1a946734c24970d1e7a6c56f34897/create_commits.py", line 111, in get_file_contents_at_commit
    text_contents = subprocess.run(
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/subprocess.py", line 507, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/subprocess.py", line 1121, in communicate
    stdout = self.stdout.read()
  File "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xdf in position 17: invalid continuation byte
```
